### PR TITLE
Add Disqus support

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -30,6 +30,7 @@
 
             <div class="post-content">
                 {{ .Content }}
+                {{ partial "modules/disqus.html" . }}
             </div>
         </div>
 	</div>

--- a/layouts/partials/modules/disqus.html
+++ b/layouts/partials/modules/disqus.html
@@ -1,0 +1,14 @@
+{{ with .Site.DisqusShortname }}
+<div id="disqus_thread"></div>
+<script>
+(function() {
+var d = document, s = d.createElement('script');
+
+s.src = '//{{ . }}.disqus.com/embed.js';
+
+s.setAttribute('data-timestamp', +new Date());
+(d.head || d.body).appendChild(s);
+})();
+</script>
+<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>
+{{ end }}


### PR DESCRIPTION
Since I want to use Disqus in my blog with nofancy, I made this PR.

I borrowed some ides from [enten/hyde-y](https://github.com/enten/hyde-y).
## Config

Add `disqusShortname` value to config file like below.

**config.toml**

``` toml
baseurl = "http://blog.example.com/"
title = "some blog"
theme = "nofancy"
disqusShortname = "disqusshortname" # <- HERE!

[permalinks]
    post = "/posts/:year/:month/:slug/"
```
