### PR TITLE
Use cdnjs and use relative paths

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -15,12 +15,12 @@
   <link rel="stylesheet" href="{{ .Site.BaseURL }}css/fonts.css">
   
   <!-- CSS –––––––––––––––––––––––––––––––––––––––––––––––––– -->
-  <link rel="stylesheet" href="http://yui.yahooapis.com/pure/0.6.0/pure-min.css">
+  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/pure/0.6.0/pure-min.css">
   <!--[if lte IE 8]>
-    <link rel="stylesheet" href="http://yui.yahooapis.com/pure/0.6.0/grids-responsive-old-ie-min.css">
+    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/pure/0.6.0/grids-responsive-old-ie-min.css">
 <![endif]-->
 <!--[if gt IE 8]><!-->
-    <link rel="stylesheet" href="http://yui.yahooapis.com/pure/0.6.0/grids-responsive-min.css">
+    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/pure/0.6.0/grids-responsive-min.css">
 <!--<![endif]-->
   <link rel="stylesheet" href="{{ .Site.BaseURL }}css/custom.css">
 


### PR DESCRIPTION
I stumbled over this while trying to launch my blog. Using a relative path should in theory be better as it leaves the choice of protocol to the browser.

Also, use CDN.js for working SSL, as the  `yahooapis.com` domain apparently has no valid certificate at the moment (?)
